### PR TITLE
Update TreeExportCli.java

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
@@ -139,7 +139,7 @@ public class TreeExportCli {
         sb.append(System.lineSeparator())
             .append(System.lineSeparator());
 
-        sb.append("Example: ast-dump --format xml --language java MyFile.java")
+        sb.append("Example: ast-dump --format xml --language java --file MyFile.java")
             .append(System.lineSeparator());
 
         System.err.print(sb);


### PR DESCRIPTION
missing --file arg in "Example: ast-dump --format xml --language java --file MyFile.java" added

## Describe the PR

Example in the code is missing --file arg so when you run
```
./dist/pmd-bin/bin/run.sh  ast-dump -f xml --language java   HelloWorld.java
```
you will get this message:
Example: ast-dump --format xml --language java MyFile.java

Message should have been:

```
Example: ast-dump --format xml --language java --file MyFile.java
````

## Related issues



- Fixes #
This fix will solve this usage message issue

## Ready?

 

- [ x] Added unit tests for fixed bug/feature
- [ x] Passing all unit tests
- [x ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ x] Added (in-code) documentation (if needed)

